### PR TITLE
ci: Dependabot の patch/minor を自動マージ

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,34 @@
+name: Dependabot auto-merge
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    # Dependabot が作成した PR のみ対象
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for patch and minor updates
+        # patch もしくは minor アップデートのみ自動マージを有効化
+        # (major は対象外なので手動でレビュー・マージする)
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要
Dependabot の PR のうち **patch / minor アップデート**を、CI(PR Validation)通過後に自動マージする仕組みを追加します。

## 変更点
- `.github/workflows/dependabot-auto-merge.yml` を追加
  - `dependabot/fetch-metadata` で更新種別を判定
  - `version-update:semver-patch` / `version-update:semver-minor` のみ `gh pr merge --auto --squash` で自動マージを有効化
  - major は対象外(手動レビュー)

## 併せて実施したリポジトリ設定(コード外)
- `allow_auto_merge` を有効化
- ruleset `main_protection` に必須チェック `validate (18.x)` / `validate (20.x)` を追加
  → 自動マージは CI 通過を待ってから実行される

🤖 Generated with [Claude Code](https://claude.com/claude-code)